### PR TITLE
Readme colons

### DIFF
--- a/spec/fixtures/apache2-README.md
+++ b/spec/fixtures/apache2-README.md
@@ -364,8 +364,8 @@ Apache module 'xsendfile'
 License and Author
 ------------------
 
-Author:: Opscode, Inc. (<cookbooks@opscode.com>)
+Author: Opscode, Inc. (<cookbooks@opscode.com>)
 
-Copyright:: 2013, Opscode, Inc.
+Copyright: 2013, Opscode, Inc.
 
-License:: Apache 2.0
+License: Apache 2.0

--- a/spec/fixtures/git-README.md
+++ b/spec/fixtures/git-README.md
@@ -35,8 +35,8 @@ Provisions a system-wide Git config
 License and Author
 ------------------
 
-Author:: Mathias Lafeldt (<mathias.lafeldt@gmail.com>)
+Author: Mathias Lafeldt (<mathias.lafeldt@gmail.com>)
 
-Copyright:: 2013, Mathias Lafeldt
+Copyright: 2013, Mathias Lafeldt
 
-License:: Apache 2.0
+License: Apache 2.0

--- a/spec/fixtures/mysql-README.md
+++ b/spec/fixtures/mysql-README.md
@@ -199,8 +199,8 @@ Performs EC2-specific mountpoint manipulation
 License and Author
 ------------------
 
-Author:: Opscode, Inc. (<cookbooks@opscode.com>)
+Author: Opscode, Inc. (<cookbooks@opscode.com>)
 
-Copyright:: 2013, Opscode, Inc.
+Copyright: 2013, Opscode, Inc.
 
-License:: Apache 2.0
+License: Apache 2.0

--- a/spec/readme_spec.rb
+++ b/spec/readme_spec.rb
@@ -90,6 +90,10 @@ module KnifeCookbookReadme
       let(:template)      { File.read(template_file) }
       let(:fixtures_path) { File.expand_path("../fixtures", __FILE__) }
 
+      before(:each) do
+        Time.stub(:now).and_return(Time.new(2013, 6, 1))
+      end
+
       it "renders README.md for apache2 cookbook" do
         metadata_file = File.join(fixtures_path, "apache2-metadata.rb")
         readme_file   = File.join(fixtures_path, "apache2-README.md")

--- a/template/README.md.erb
+++ b/template/README.md.erb
@@ -65,8 +65,8 @@ Recipes
 License and Author
 ------------------
 
-Author:: <%= author %> (<<%= author_email %>>)
+Author: <%= author %> (<<%= author_email %>>)
 
-Copyright:: <%= copyright_year %>, <%= author %>
+Copyright: <%= copyright_year %>, <%= author %>
 
-License:: <%= license %>
+License: <%= license %>


### PR DESCRIPTION
I think the README looks funny with two colons after 'Author', 'Copyright', and 'License' (at least when rendered in Github-flavored markdown).  I propose changing it to one, as per this pull request.

I also found that there was a test that was failing when the suite was run outside of 2013, so I stubbed Time.now to make it work in any year.  This is in a separate commit because it's logically separate; let me know if you'd prefer for me to issue two separate pull requests instead of one.
